### PR TITLE
[Feature] Mod lists now show design team in place of all co-authors

### DIFF
--- a/content/mods/zt2/animals/ambients/wahoo/index.md
+++ b/content/mods/zt2/animals/ambients/wahoo/index.md
@@ -18,7 +18,6 @@ alt_text:
 languages:
 - English
 summary: "The Wahoo is a game fish, found in the open see, and is related to the Marlin and Mackerel."
-
 ---
 
 Note: this is an ambient, not an adoptable animal. This means it will spawn in the environment at random intervals.

--- a/content/teams/artifex/index.md
+++ b/content/teams/artifex/index.md
@@ -1,0 +1,18 @@
+---
+title: "Artifex"
+draft: false
+date: '2024-08-07T13:28:26'
+members:
+- Penguinman
+- Koala Komander
+- Nique
+- Mikaboshi
+- ShenTirag
+- Goosifer
+- Budgielover101
+- Gloria
+- Steenbok28
+- SilesianTomcat
+description: "Artifex is a team of designers who created mods for Zoo Tycoon 2; notably they were the first to create expansive mods for the game. The team has origins in the Zoo Admin Design Team but became its own thing when ZA had its initial trouble with server issues."
+---
+

--- a/themes/zooberry/layouts/archives/list.html
+++ b/themes/zooberry/layouts/archives/list.html
@@ -252,17 +252,24 @@
                                             {{ end }}
                                             </p>
                                         <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-                                        <p>by {{ $authors := .Params.author }}
-                            
-                                            {{ $len := len $authors }}
-                                            {{ if eq $len 1 }}
-                                                {{ index $authors 0 }}
-                                            {{ else if eq $len 2 }}
-                                                {{ index $authors 0 }} and {{ index $authors 1 }}
+                                        <p>by 
+                                            {{ $authors := .Params.author }}
+                                            {{ $siteBaseURL := .Site.BaseURL }}    
+                                            {{ with .Params.team }}
+                                                <a href="{{ $siteBaseURL }}teams/{{ . | urlize }}">{{ . }}</a>
                                             {{ else }}
-                                                {{ index $authors 0 }}, {{ index $authors 1 }}, and {{ add $len -2 }} more
+                                                {{ with $authors }}
+                                                    {{ $len := len $authors }}
+                                                    {{ if eq $len 1 }}
+                                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
+                                                    {{ else if eq $len 2 }}
+                                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                                                    {{ else }}
+                                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                                                    {{ end }}
+                                                {{ end }}
                                             {{ end }}
-                                        </p>
+                                                        </p>
                                         <span class="box-card-bottom">
                                             {{ partial "class-badges.html" . }}
                                             <span class="box-card-date">{{ .Date.Format "2 Jan 2006" }}</span>

--- a/themes/zooberry/layouts/author/author.html
+++ b/themes/zooberry/layouts/author/author.html
@@ -131,17 +131,24 @@
                                     {{ end }}
                                     </p>
                                 <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-                                <p>by {{ $authors := .Params.author }}
-                    
-                                    {{ $len := len $authors }}
-                                    {{ if eq $len 1 }}
-                                        {{ index $authors 0 }}
-                                    {{ else if eq $len 2 }}
-                                        {{ index $authors 0 }} and {{ index $authors 1 }}
+                                <p>by 
+                                    {{ $authors := .Params.author }}
+                                    {{ $siteBaseURL := .Site.BaseURL }}    
+                                    {{ with .Params.team }}
+                                        <a href="{{ $siteBaseURL }}teams/{{ . | urlize }}">{{ . }}</a>
                                     {{ else }}
-                                        {{ index $authors 0 }}, {{ index $authors 1 }}, and {{ add $len -2 }} more
+                                        {{ with $authors }}
+                                            {{ $len := len $authors }}
+                                            {{ if eq $len 1 }}
+                                                <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
+                                            {{ else if eq $len 2 }}
+                                                <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                                            {{ else }}
+                                                <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                                            {{ end }}
+                                        {{ end }}
                                     {{ end }}
-                                </p>
+                                        </p>
                                 <span class="box-card-bottom">
                                     {{ partial "class-badges.html" . }}
                                     <span class="box-card-date">{{ .Date.Format "2 Jan 2006" }}</span>

--- a/themes/zooberry/layouts/partials/range-mods-list.html
+++ b/themes/zooberry/layouts/partials/range-mods-list.html
@@ -49,17 +49,25 @@
                 {{ end }}
                 </p>
             <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-            <p>by {{ $authors := .Params.author }}
+            <p>by 
 
-                {{ $len := len $authors }}
-                {{ if eq $len 1 }}
-                    <a href="{{ .Site.BaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
-                {{ else if eq $len 2 }}
-                    <a href="{{ .Site.BaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ .Site.BaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                {{ $authors := .Params.author }}
+                {{ $siteBaseURL := .Site.BaseURL }}    
+                {{ with .Params.team }}
+                    <a href="{{ $siteBaseURL }}teams/{{ . | urlize }}">{{ . }}</a>
                 {{ else }}
-                    <a href="{{ .Site.BaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ .Site.BaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                    {{ with $authors }}
+                        {{ $len := len $authors }}
+                        {{ if eq $len 1 }}
+                            <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
+                        {{ else if eq $len 2 }}
+                            <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                        {{ else }}
+                            <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                        {{ end }}
+                    {{ end }}
                 {{ end }}
-            </p>
+</p>
             <span class="box-card-bottom">
                 {{ partial "class-badges.html" . }}
                 <span class="box-card-date">{{ .Date.Format "2 Jan 2006" }}</span>

--- a/themes/zooberry/layouts/partials/range-mods.html
+++ b/themes/zooberry/layouts/partials/range-mods.html
@@ -27,16 +27,22 @@
             <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
             <p>by 
                 {{ $authors := .Params.author }}
-
-                {{ $len := len $authors }}
-                {{ if eq $len 1 }}
-                    {{ index $authors 0 }}
-                {{ else if eq $len 2 }}
-                    {{ index $authors 0 }} and {{ index $authors 1 }}
+                {{ $siteBaseURL := .Site.BaseURL }}    
+                {{ with .Params.team }}
+                    <a href="{{ $siteBaseURL }}teams/{{ . | urlize }}">{{ . }}</a>
                 {{ else }}
-                    {{ index $authors 0 }}, {{ index $authors 1 }}, and {{ add $len -2 }} more
+                    {{ with $authors }}
+                        {{ $len := len $authors }}
+                        {{ if eq $len 1 }}
+                            <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
+                        {{ else if eq $len 2 }}
+                            <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                        {{ else }}
+                            <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                        {{ end }}
+                    {{ end }}
                 {{ end }}
-            </p>
+</p>
             <span class="box-card-bottom">
                 <span class="badge-animals">Animals</span>
                 <span class="box-card-date">{{ .Date.Format "2 Jan 2006" }}</span>

--- a/themes/zooberry/layouts/taxonomy/archives.html
+++ b/themes/zooberry/layouts/taxonomy/archives.html
@@ -251,17 +251,24 @@
                                             {{ end }}
                                             </p>
                                         <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-                                        <p>by {{ $authors := .Params.author }}
-                            
-                                            {{ $len := len $authors }}
-                                            {{ if eq $len 1 }}
-                                                {{ index $authors 0 }}
-                                            {{ else if eq $len 2 }}
-                                                {{ index $authors 0 }} and {{ index $authors 1 }}
+                                        <p>by 
+                                            {{ $authors := .Params.author }}
+                                            {{ $siteBaseURL := .Site.BaseURL }}    
+                                            {{ with .Params.team }}
+                                                <a href="{{ $siteBaseURL }}teams/{{ . | urlize }}">{{ . }}</a>
                                             {{ else }}
-                                                {{ index $authors 0 }}, {{ index $authors 1 }}, and {{ add $len -2 }} more
+                                                {{ with $authors }}
+                                                    {{ $len := len $authors }}
+                                                    {{ if eq $len 1 }}
+                                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
+                                                    {{ else if eq $len 2 }}
+                                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                                                    {{ else }}
+                                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                                                    {{ end }}
+                                                {{ end }}
                                             {{ end }}
-                                        </p>
+                                                        </p>
                                         <span class="box-card-bottom">
                                             {{ partial "class-badges.html" . }}
                                             <span class="box-card-date">{{ .Date.Format "2 Jan 2006" }}</span>

--- a/themes/zooberry/layouts/taxonomy/zt1tags.html
+++ b/themes/zooberry/layouts/taxonomy/zt1tags.html
@@ -97,20 +97,24 @@
                             {{ end }}
                             </p>
                         <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-                        <p>by {{ $authors := .Params.author }}
-
-                            {{ $siteBaseURL := .Site.BaseURL }}
-                            {{ with $authors }}
-                                {{ $len := len . }}
-
-                                {{ if eq $len 1 }}
-                                    <a href="{{ $siteBaseURL }}authors/{{ index . 0 | urlize }}">{{ index . 0 }}</a>
-                                {{ else if eq $len 2 }}
-                                    <a href="{{ $siteBaseURL }}authors/{{ index . 0 | urlize }}">{{ index . 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index . 1 | urlize }}">{{ index . 1 }}</a>
-                                {{ else }}
-                                    <a href="{{ $siteBaseURL }}authors/{{ index . 0 | urlize }}">{{ index . 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index . 1 | urlize }}">{{ index . 1 }}</a> and {{ sub $len 2 }} more
+                        <p>by                                     
+                            {{ $authors := .Params.author }}
+                            {{ $siteBaseURL := .Site.BaseURL }}    
+                            {{ with .Params.team }}
+                                <a href="{{ $siteBaseURL }}teams/{{ . | urlize }}">{{ . }}</a>
+                            {{ else }}
+                                {{ with $authors }}
+                                    {{ $len := len $authors }}
+                                    {{ if eq $len 1 }}
+                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
+                                    {{ else if eq $len 2 }}
+                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                                    {{ else }}
+                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                                    {{ end }}
                                 {{ end }}
                             {{ end }}
+
                         </p>
                         <span class="box-card-bottom">
                             {{ partial "class-badges.html" . }}

--- a/themes/zooberry/layouts/taxonomy/zt2tags.html
+++ b/themes/zooberry/layouts/taxonomy/zt2tags.html
@@ -97,18 +97,22 @@
                             {{ end }}
                             </p>
                         <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-                        <p>by {{ $authors := .Params.author }}
+                        <p>by
 
-                            {{ $siteBaseURL := .Site.BaseURL }}
-                            {{ with $authors }}
-                                {{ $len := len . }}
-
-                                {{ if eq $len 1 }}
-                                    <a href="{{ $siteBaseURL }}authors/{{ index . 0 | urlize }}">{{ index . 0 }}</a>
-                                {{ else if eq $len 2 }}
-                                    <a href="{{ $siteBaseURL }}authors/{{ index . 0 | urlize }}">{{ index . 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index . 1 | urlize }}">{{ index . 1 }}</a>
-                                {{ else }}
-                                    <a href="{{ $siteBaseURL }}authors/{{ index . 0 | urlize }}">{{ index . 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index . 1 | urlize }}">{{ index . 1 }}</a> and {{ sub $len 2 }} more
+                            {{ $authors := .Params.author }}
+                            {{ $siteBaseURL := .Site.BaseURL }}    
+                            {{ with .Params.team }}
+                                <a href="{{ $siteBaseURL }}teams/{{ . | urlize }}">{{ . }}</a>
+                            {{ else }}
+                                {{ with $authors }}
+                                    {{ $len := len $authors }}
+                                    {{ if eq $len 1 }}
+                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
+                                    {{ else if eq $len 2 }}
+                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                                    {{ else }}
+                                        <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                                    {{ end }}
                                 {{ end }}
                             {{ end }}
                         </p>

--- a/themes/zooberry/layouts/teams/single.html
+++ b/themes/zooberry/layouts/teams/single.html
@@ -122,17 +122,24 @@
                                     {{ end }}
                                     </p>
                                 <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-                                <p>by {{ $authors := .Params.author }}
-                    
-                                    {{ $len := len $authors }}
-                                    {{ if eq $len 1 }}
-                                        {{ index $authors 0 }}
-                                    {{ else if eq $len 2 }}
-                                        {{ index $authors 0 }} and {{ index $authors 1 }}
+                                <p>by 
+                                    {{ $authors := .Params.author }}
+                                    {{ $siteBaseURL := .Site.BaseURL }}    
+                                    {{ with .Params.team }}
+                                        <a href="{{ $siteBaseURL }}teams/{{ . | urlize }}">{{ . }}</a>
                                     {{ else }}
-                                        {{ index $authors 0 }}, {{ index $authors 1 }}, and {{ add $len -2 }} more
+                                        {{ with $authors }}
+                                            {{ $len := len $authors }}
+                                            {{ if eq $len 1 }}
+                                                <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>
+                                            {{ else if eq $len 2 }}
+                                                <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a> and <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a>
+                                            {{ else }}
+                                                <a href="{{ $siteBaseURL }}authors/{{ index $authors 0 | urlize }}">{{ index $authors 0 }}</a>, <a href="{{ $siteBaseURL }}authors/{{ index $authors 1 | urlize }}">{{ index $authors 1 }}</a> and {{ sub $len 2 }} more
+                                            {{ end }}
+                                        {{ end }}
                                     {{ end }}
-                                </p>
+                                        </p>
                                 <span class="box-card-bottom">
                                     {{ partial "class-badges.html" . }}
                                     <span class="box-card-date">{{ .Date.Format "2 Jan 2006" }}</span>


### PR DESCRIPTION
Mod lists show design team name instead of list of co-authors as a preventive measure for mods that have too many authors. This avoids theme breaking while still giving users credit on their own pages where the mods is added to file count and list of mods.